### PR TITLE
fix: windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^12.11.7",
     "@types/tmp": "^0.2.0",
     "@types/rimraf": "^3.0.0",
+    "@types/which": "2.0.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "coc.nvim": "^0.0.80",
@@ -49,7 +50,8 @@
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "which": "^2.0.2"
   },
   "activationEvents": [
     "onLanguage:python"

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -11,6 +11,7 @@ import { PYSEN_LS_VERSION } from './constant';
 const exec = util.promisify(child_process.exec);
 
 export async function pysenLsInstall(
+  pythonCommand: string,
   context: ExtensionContext,
   flake8Version?: string,
   mypyVersion?: string,
@@ -18,10 +19,14 @@ export async function pysenLsInstall(
   isortVersion?: string
 ): Promise<void> {
   const pathVenv = path.join(context.storagePath, 'pysen-ls', 'venv');
-  const pathPip = path.join(pathVenv, 'bin', 'pip');
+
+  let pathVenvPython = path.join(context.storagePath, 'pysen-ls', 'venv', 'bin', 'python');
+  if (process.platform === 'win32') {
+    pathVenvPython = path.join(context.storagePath, 'pysen-ls', 'venv', 'Scripts', 'python');
+  }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });
-  statusItem.text = `Install pysen-ls and more tools ...`;
+  statusItem.text = `Install pysen-ls and more tools...`;
   statusItem.show();
 
   const installFlake8Str = _installToolVersionStr('flake8', flake8Version);
@@ -31,15 +36,14 @@ export async function pysenLsInstall(
 
   const installCmd =
     `python3 -m venv ${pathVenv} && ` +
-    `${pathPip} install -U pip pysen-ls==${PYSEN_LS_VERSION} ${installFlake8Str} ${installMypyStr} ${installBlackStr} ${installIsortStr}`;
+    `${pathVenvPython} -m pip install -U pip pysen-ls==${PYSEN_LS_VERSION} ${installFlake8Str} ${installMypyStr} ${installBlackStr} ${installIsortStr}`;
 
   rimraf.sync(pathVenv);
   try {
-    //window.showMessage(`Install pysen-ls and more tools ...`);
-    window.showWarningMessage(`Install pysen-ls and more tools ...`);
+    window.showMessage(`Install pysen-ls and more tools...`);
     await exec(installCmd);
     statusItem.hide();
-    window.showWarningMessage(`pysen-ls: installed!`);
+    window.showMessage(`pysen-ls: installed!`);
   } catch (error) {
     statusItem.hide();
     window.showErrorMessage(`pysen-ls: install failed. | ${error}`);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -35,7 +35,7 @@ export async function pysenLsInstall(
   const installIsortStr = _installToolVersionStr('isort', isortVersion);
 
   const installCmd =
-    `python3 -m venv ${pathVenv} && ` +
+    `${pythonCommand} -m venv ${pathVenv} && ` +
     `${pathVenvPython} -m pip install -U pip pysen-ls==${PYSEN_LS_VERSION} ${installFlake8Str} ${installMypyStr} ${installBlackStr} ${installIsortStr}`;
 
   rimraf.sync(pathVenv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,6 +100,11 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
   integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
 
+"@types/which@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.0.tgz#446d35586611dee657120de8e0457382a658fc25"
+  integrity sha512-JHTNOEpZnACQdsTojWggn+SQ8IucfqEhtz7g8Z0G67WdSj4x3F0X5I2c/CVcl8z/QukGrIHeQ/N49v1au74XFQ==
+
 "@typescript-eslint/eslint-plugin@^4.8.2":
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.21.0.tgz#3fce2bfa76d95c00ac4f33dff369cb593aab8878"
@@ -1086,7 +1091,7 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
- Fix path of venv on windows (Change to Scripts instead of bin.)
- Change the installation procedure to `python -m pip` instead of using pip in venv directly.
- Added python3 and python command detection (since python3 commands may not be present on Windows and other special environments).