### PR TITLE
feat(option): add "pysen.trace.server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can also run the installation command manually.
 - `pysen.server.enableCodeAction`: Enable/disable code actions, default: `true`
 - `pysen.server.lintTargets`: Controls target names for pysen to invoke in the lint task, default: `["lint"]`
 - `pysen.server.formatTargets`: Controls target names for pysen to invoke in the format task, default: `["format", "lint"]`
+- `pysen.trace.server`: Traces the communication between coc.nvim and the pysen language server, default: `"off"`
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -157,6 +157,16 @@
             "lint"
           ],
           "description": "Controls target names for pysen to invoke in the format task."
+        },
+        "pysen.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between coc.nvim and the pysen language server."
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     initializationOptions: { config: serverConfig },
   };
 
-  client = new LanguageClient('pysen language server', serverOptions, clientOptions);
+  client = new LanguageClient('pysen', 'pysen language server', serverOptions, clientOptions);
 
   client.start();
 }


### PR DESCRIPTION
Add the `pysen.trace.server` setting to the configuration option, so that configuration completion also works in coc-settings.json. (In the case of vscode, it's settings.json)